### PR TITLE
Allow Text Children

### DIFF
--- a/src/__tests__/integrations/DeepWrapRegression--test.js
+++ b/src/__tests__/integrations/DeepWrapRegression--test.js
@@ -350,5 +350,52 @@ describe('Deep Wrap', () => {
     ).toBe(EXPECTED_STATE_VALUE);
 
   });
-});
 
+  it('works with non-element children', () => {
+    const nodeWithTextChild = ({ test, children, actions }) => {
+      return (
+        <div onClick={actions.triggerUpdate}>
+          {test} {children}
+        </div>
+      );
+    };
+
+    const NodeWithTextChild = wrap(nodeWithTextChild, {
+      mapStateToProps() {
+        return {
+          test: 'test',
+        };
+      },
+      actions: {
+        triggerUpdate(props, next) {
+          next({ test: 'bar' });
+        },
+      },
+    });
+
+    const store = {
+      test: 'foo',
+    };
+
+    const tree = mount(
+      <Provider store={store}>
+        <NodeWithTextChild>
+          test
+        </NodeWithTextChild>
+      </Provider>
+    );
+
+    /*
+     * simulate the click to update state
+     */
+    const nodeWrapper = tree.find('[onClick]');
+    nodeWrapper.simulate('click');
+
+    /*
+     * EXPECTATION
+     */
+    expect(
+      nodeWrapper.text()
+    ).toBe('bar test');
+  });
+});

--- a/src/wrapComponent.js
+++ b/src/wrapComponent.js
@@ -22,6 +22,10 @@ export default function wrapComponent(Component:Function, config:Object):Functio
     arrayChildren.forEach(buildGranchildDependencies);
 
     function buildGranchildDependencies(child) : void {
+      // Bail if child is not a component (e.g. a string)
+      if (!React.isValidElement(child)) {
+        return;
+      }
       const childComponent:Object = child.type.nativeComponent;
 
       if (!childComponent) {


### PR DESCRIPTION
This allows dependency trees to be built for nodes with text children. This was the error I was seeing before:

```
wrapComponent.js:39 Uncaught TypeError: Cannot read property 'nativeComponent' of undefined

buildGranchildDependencies @ wrapComponent.js:39childDependencies @ 
wrapComponent.js:36shouldComponentUpdate @ CofluxContainer.js:58updateComponent @ 
ReactCompositeComponent.js:656receiveComponent @ 
ReactCompositeComponent.js:571receiveComponent @ 
ReactReconciler.js:127_updateRenderedComponent @ 
...
```

The added test will fail with the same exception if the change to `wrapComponent` is removed.
